### PR TITLE
Return the value from the function in batch/2

### DIFF
--- a/lib/dogstatsd/statsd.ex
+++ b/lib/dogstatsd/statsd.ex
@@ -80,8 +80,10 @@ defmodule DogStatsd.Statsd do
       end
 
       def batch(dogstatsd, function) do
-        function.(DogStatsd.Batched)
+        res = function.(DogStatsd.Batched)
         DogStatsd.flush_buffer(dogstatsd)
+
+        res
       end
 
       def send_stats(dogstatsd, stat, delta, type, opts \\ %{})

--- a/test/dogstatsd_test.exs
+++ b/test/dogstatsd_test.exs
@@ -324,6 +324,16 @@ defmodule DogStatsdTest do
     assert_receive {:udp, _port, _from_ip, _from_port, 'mycounter:1|c'}
   end
 
+  test "returns the return value of the block" do
+    ret = DogStatsd.batch :dogstatsd, fn(s) ->
+      s.increment(:dogstatsd, "mycounter")
+
+      :fn_return_val
+    end
+
+    assert ret == :fn_return_val
+  end
+
   test "allows sending multiple samples in one packet" do
     DogStatsd.batch :dogstatsd, fn(s) ->
       s.increment(:dogstatsd, "mycounter")


### PR DESCRIPTION
Since batch/2 is intended to buffer requests, returning the return value of the passed function can be handy in use cases like the example below, where we care for the return value.

```elixir
map = DogStatsd.batch statsd, fn (statsd) ->
  for i <- 1..10_000, into: %{}, do 
    s.increment(statsd, "numbers")
    {"key_#{i}", i}
  end
end

some_function(map)
```