### PR TITLE
Replace deprecated String.to_char_list/1 with String.to_charlist/1

### DIFF
--- a/lib/dogstatsd/statsd.ex
+++ b/lib/dogstatsd/statsd.ex
@@ -121,9 +121,9 @@ defmodule DogStatsd.Statsd do
 
         {:ok, socket} = :gen_udp.open(0)
         :gen_udp.send(socket,
-                      host(dogstatsd) |> String.to_char_list,
+                      host(dogstatsd) |> String.to_charlist,
                       port(dogstatsd),
-                      message |> String.to_char_list)
+                      message |> String.to_charlist)
         :gen_udp.close(socket)
       end
 

--- a/test/dogstatsd_test.exs
+++ b/test/dogstatsd_test.exs
@@ -360,7 +360,7 @@ defmodule DogStatsdTest do
     theoretical_reply = Enum.into(1..50, [])
                         |> Enum.map(fn(_) -> "mycounter:1|c" end)
                         |> Enum.join("\n")
-                        |> String.to_char_list
+                        |> String.to_charlist
 
 
     assert_receive {:udp, _port, _from_ip, _from_port, ^theoretical_reply}


### PR DESCRIPTION
## Context

The `String.to_char_list/1` has been deprecated. Users are recommended to replace it with `String.to_charlist/1`

## Changes

* `s/char_list/charlist`

cc @adamkittelson 